### PR TITLE
Add HuggingFace maintainers to the feedstock repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ Feedstock Maintainers
 =====================
 
 * [@BastianZim](https://github.com/BastianZim/)
+

--- a/README.md
+++ b/README.md
@@ -117,6 +117,3 @@ Feedstock Maintainers
 =====================
 
 * [@BastianZim](https://github.com/BastianZim/)
-* [@adrinjalali](https://github.com/adrinjalali)
-* [@LysandreJik](https://github.com/LysandreJik)
-* [@osanseviero](https://github.com/osanseviero)

--- a/README.md
+++ b/README.md
@@ -117,4 +117,6 @@ Feedstock Maintainers
 =====================
 
 * [@BastianZim](https://github.com/BastianZim/)
-
+* [@adrinjalali](https://github.com/adrinjalali)
+* [@LysandreJik](https://github.com/LysandreJik)
+* [@osanseviero](https://github.com/osanseviero)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,3 +51,6 @@ about:
 extra:
   recipe-maintainers:
     - BastianZim
+    - adrinjalali
+    - LysandreJik
+    - osanseviero


### PR DESCRIPTION
Thanks for all the work you've been doing for this project @BastianZim.

We've realized the conda-forge team has been very kindly maintaining the package w/o any involvement of the maintainers of the library.

We're happy to be added to the maintainers list here and handle feedstock's issues/prs if/when they happen.

To start, I think we can have these 3 added:
- @adrinjalali 
- @LysandreJik 
- @osanseviero

We all work at @huggingface and maintain the original repo: https://github.com/huggingface/huggingface_hub
I'm also a maintainer of `scikit-learn` and `fairlearn` on conda-forge.