### PR TITLE
feat: Add support for `hf` and `tiny-agents` as installed scripts

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,4 +7,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,14 @@ source:
   sha256: a4228daa6fb001be3f4f4bdaf9a0db00e1739235702848df00885c9b5742c85c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - huggingface-cli=huggingface_hub.commands.huggingface_cli:main
+    - hf=huggingface_hub.cli.hf:main
+    # Note: This cannot be tested out of the box since it requires `mcp` and `typer` as
+    # additional optional dependencies.
+    - tiny-agents=huggingface_hub.inference._mcp.cli:app
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -41,6 +45,9 @@ test:
   commands:
     - pip check
     - huggingface-cli --help
+    - huggingface-cli env
+    - hf --help
+    - hf env
   requires:
     - pip
     - python {{ python_min }}
@@ -51,13 +58,13 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   description: |
-    The `huggingface_hub` is a client library to interact with the Hugging Face Hub. 
-    The Hugging Face Hub is a platform with over 35K models, 4K datasets, and 2K 
-    demos in which people can easily collaborate in their ML workflows. The Hub works 
-    as a central place where anyone can share, explore, discover, and experiment with 
+    The `huggingface_hub` is a client library to interact with the Hugging Face Hub.
+    The Hugging Face Hub is a platform with over 35K models, 4K datasets, and 2K
+    demos in which people can easily collaborate in their ML workflows. The Hub works
+    as a central place where anyone can share, explore, discover, and experiment with
     open-source Machine Learning.
 
-    With `huggingface_hub`, you can easily download and upload models, extract useful 
+    With `huggingface_hub`, you can easily download and upload models, extract useful
     information from the Hub, and do much more. Some example use cases:
 
     - Downloading and caching files from a Hub repository.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,19 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   description: |
-    The huggingface_hub library allows you to interact with the Hugging Face Hub, a platform democratizing open-source Machine Learning for creators and collaborators. Discover pre-trained models and datasets for your projects or play with the thousands of machine learning apps hosted on the Hub. You can also create and share your own models, datasets and demos with the community. The huggingface_hub library provides a simple way to do all these things with Python.
+     The `huggingface_hub` is a client library to interact with the Hugging Face Hub.
+     The Hugging Face Hub is a platform with over 2M models, 500K datasets, and 200K
+     demos in which people can easily collaborate in their ML workflows. The Hub works
+     as a central place where anyone can share, explore, discover, and experiment with
+     open-source Machine Learning.
+
+     With `huggingface_hub`, you can easily download and upload models, extract useful
+     information from the Hub, and do much more. Some example use cases:
+
+    - Downloading and caching files from a Hub repository.
+    - Creating repositories and uploading an updated model every few epochs.
+    - Extract metadata from all models that match certain criteria (e.g. models for `text-classification`).
+    - List all files from a specific repository.
 
     PyPI: [https://pypi.org/project/huggingface-hub/](https://pypi.org/project/huggingface-hub/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,14 +58,14 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   description: |
-     The `huggingface_hub` is a client library to interact with the Hugging Face Hub.
-     The Hugging Face Hub is a platform with over 2M models, 500K datasets, and 200K
-     demos in which people can easily collaborate in their ML workflows. The Hub works
-     as a central place where anyone can share, explore, discover, and experiment with
-     open-source Machine Learning.
+    The `huggingface_hub` is a client library to interact with the Hugging Face Hub.
+    The Hugging Face Hub is a platform with over 2M models, 500K datasets, and 200K
+    demos in which people can easily collaborate in their ML workflows. The Hub works
+    as a central place where anyone can share, explore, discover, and experiment with
+    open-source Machine Learning.
 
-     With `huggingface_hub`, you can easily download and upload models, extract useful
-     information from the Hub, and do much more. Some example use cases:
+    With `huggingface_hub`, you can easily download and upload models, extract useful
+    information from the Hub, and do much more. Some example use cases:
 
     - Downloading and caching files from a Hub repository.
     - Creating repositories and uploading an updated model every few epochs.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,19 +58,7 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   description: |
-    The `huggingface_hub` is a client library to interact with the Hugging Face Hub.
-    The Hugging Face Hub is a platform with over 35K models, 4K datasets, and 2K
-    demos in which people can easily collaborate in their ML workflows. The Hub works
-    as a central place where anyone can share, explore, discover, and experiment with
-    open-source Machine Learning.
-
-    With `huggingface_hub`, you can easily download and upload models, extract useful
-    information from the Hub, and do much more. Some example use cases:
-
-    - Downloading and caching files from a Hub repository.
-    - Creating repositories and uploading an updated model every few epochs.
-    - Extract metadata from all models that match certain criteria (e.g. models for `text-classification`).
-    - List all files from a specific repository.
+    The huggingface_hub library allows you to interact with the Hugging Face Hub, a platform democratizing open-source Machine Learning for creators and collaborators. Discover pre-trained models and datasets for your projects or play with the thousands of machine learning apps hosted on the Hub. You can also create and share your own models, datasets and demos with the community. The huggingface_hub library provides a simple way to do all these things with Python.
 
     PyPI: [https://pypi.org/project/huggingface-hub/](https://pypi.org/project/huggingface-hub/)
 


### PR DESCRIPTION
Copy of https://github.com/conda-forge/huggingface_hub-feedstock/pull/157 but from my personal fork.

As in title. Noticed (because of https://github.com/huggingface/huggingface_hub/issues/3296) that we hadn't mapped to the recent entry point additions exposed by upstream (https://github.com/huggingface/huggingface_hub/blob/main/setup.py#L138-L139).

I also added validations using `env` command to test, which I verified runs fine from an unauthenticated Docker container using the CLI, as:
```bash
docker run --rm -it ghcr.io/astral-sh/uv:debian bash
uv run --with huggingface-hub hf env
uv run --with huggingface-hub huggingface-cli env
```

Resolves https://github.com/huggingface/huggingface_hub/issues/3296.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
